### PR TITLE
Update Keep the Score description: scoreboard app, not leaderboard

### DIFF
--- a/_posts/2021-06-22-social-media-image-generation-python.md
+++ b/_posts/2021-06-22-social-media-image-generation-python.md
@@ -8,7 +8,7 @@ image: /images/automatic.jpg
 
 In today's attention economy you need to stand out when you post your content on social media: that means having some kind of image as part of the package. This is easy if you're sharing a blog post with photos (or other images) because you can setup your system to use one of these photos. But what if you're sharing content that doesn't come with a pre-made image?
 
-This is a problem I was facing. I'm building an [online scoreboard and leaderboard app](https://keethescore.co) whose content regularly gets shared on Twitter, Facebook and elsewhere. However, these scoreboards do not come with images: they are HTML and CSS. How could I ensure they always have an image to use on social media without resorting to something generic?
+This is a problem I was facing. I'm building an [online scoreboard app](https://keepthescore.com) whose content regularly gets shared on Twitter, Facebook and elsewhere. However, these scoreboards do not come with images: they are HTML and CSS. How could I ensure they always have an image to use on social media without resorting to something generic?
 
 ## Summary
 

--- a/projects.html
+++ b/projects.html
@@ -19,7 +19,7 @@ nav: projects
                     <span class="status-online">✅ Online</span>
                     <span class="outcome-success">🎯 Success</span>
                 </div>
-                <p class="project-description">Online scoreboard and leaderboard app.</p>
+                <p class="project-description">Online scoreboard app for sports and games.</p>
                 <p class="project-status">My main project - used by 10,000+ people daily and highly profitable!</p>
                 <a href="https://keepthescore.com" target="_blank" class="btn btn-secondary btn-sm w-100 mt-2">Visit Site →</a>
             </div>


### PR DESCRIPTION
After the 2025 split, leaderboards moved to Leaderboarded.com and Keep
the Score is now a sports/games scoreboard app. Update the projects page
card and the standing product description in the 2021 social-image post
(also fixing the broken keethescore.co link).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AYNmwrFi5FcAvtxejGGKQ3